### PR TITLE
Egui based UI + fix for hang when reading serial number of Nothing Ear (2024)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ console_error_panic_hook = "0.1.7"
 log = "0.4.22"
 
 [workspace]
-members = ["nothing", "src-tauri"]
+members = ["nothing", "src-egui", "src-tauri"]
 
 [profile.release]
 lto = true

--- a/nothing/src/connect.rs
+++ b/nothing/src/connect.rs
@@ -20,9 +20,9 @@ async fn find_address(
         .find(|&addr| match addr.0 {
             [a, b, c, _, _, _] => a == address[0] && b == address[1] && c == address[2],
         })
-        .ok_or_else(|| {
+        .ok_or(
             "Couldn't find any Ear devices connected. Make sure you're paired with your Ear."
-        })?;
+        )?;
 
     Ok(*ear_address)
 }
@@ -39,5 +39,6 @@ pub async fn connect(address: [u8; 3], channel: u8) -> Result<Stream, Box<dyn st
         channel,
     })
     .await?;
+
     Ok(stream)
 }

--- a/src-egui/Cargo.toml
+++ b/src-egui/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "nothing-linux-egui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+eframe = "0.29.1"
+nothing = { path = "../nothing" }
+tokio = { version = "1.42.0", features = ["full"] }

--- a/src-egui/src/async_worker.rs
+++ b/src-egui/src/async_worker.rs
@@ -1,0 +1,65 @@
+use eframe::egui;
+use nothing::{anc::AncMode, nothing_ear_2::Ear2};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+pub enum EarCmd {
+    AncMode(AncMode),
+    LowLatency(bool),
+    InEarDetection(bool),
+}
+
+pub enum EarResponse {
+    DeviceInfo(DeviceInfo),
+    Error(String),
+}
+
+pub struct DeviceInfo {
+    pub address: String,
+    pub firmware_version: String,
+    pub serial_number: String,
+}
+
+pub async fn async_worker(
+    mut rx: UnboundedReceiver<EarCmd>,
+    tx: UnboundedSender<EarResponse>,
+    ctx: egui::Context,
+) {
+    let send_response = |response: EarResponse| async {
+        tx.send(response).expect("sending EarResponse");
+        ctx.request_repaint();
+    };
+    let ear_2 = match Ear2::new().await {
+        Ok(ear_2) => {
+            send_response(EarResponse::DeviceInfo(DeviceInfo {
+                address: ear_2.address.clone(),
+                firmware_version: ear_2.firmware_version.clone(),
+                serial_number: ear_2.serial_number.clone(),
+            }))
+            .await;
+            ear_2
+        }
+        Err(err) => {
+            send_response(EarResponse::Error(err.to_string())).await;
+            return;
+        }
+    };
+    while let Some(cmd) = rx.recv().await {
+        match cmd {
+            EarCmd::AncMode(anc_mode) => {
+                if let Err(err) = ear_2.set_anc(anc_mode).await {
+                    send_response(EarResponse::Error(err.to_string())).await;
+                }
+            }
+            EarCmd::LowLatency(mode) => {
+                if let Err(err) = ear_2.set_low_latency(mode).await {
+                    send_response(EarResponse::Error(err.to_string())).await;
+                }
+            }
+            EarCmd::InEarDetection(mode) => {
+                if let Err(err) = ear_2.set_in_ear_detection(mode).await {
+                    send_response(EarResponse::Error(err.to_string())).await;
+                }
+            }
+        }
+    }
+}

--- a/src-egui/src/main.rs
+++ b/src-egui/src/main.rs
@@ -1,0 +1,261 @@
+use eframe::egui;
+
+use async_worker::{async_worker, DeviceInfo, EarCmd, EarResponse};
+use nothing::anc::AncMode;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+mod async_worker;
+
+fn main() -> eframe::Result {
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([200.0, 400.0]),
+        ..Default::default()
+    };
+
+    let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (response_tx, response_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    eframe::run_native(
+        "nothing-linux",
+        options,
+        Box::new(|cc| {
+            let ctx = cc.egui_ctx.clone();
+
+            std::thread::spawn(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+
+                rt.block_on(async {
+                    async_worker(cmd_rx, response_tx, ctx).await;
+                });
+            });
+
+            Ok(Box::new(MyApp::new(cmd_tx, response_rx)))
+        }),
+    )
+}
+
+#[derive(PartialEq, Eq)]
+pub enum UiAnc {
+    On,
+    Transparency,
+    Off,
+    Unknown,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum UiAncMode {
+    High,
+    Mid,
+    Low,
+    Adaptive,
+}
+
+impl UiAncMode {
+    fn label(&self) -> &str {
+        match self {
+            UiAncMode::High => "High",
+            UiAncMode::Mid => "Mid",
+            UiAncMode::Low => "Low",
+            UiAncMode::Adaptive => "Adaptive",
+        }
+    }
+}
+
+impl From<&UiAncMode> for AncMode {
+    fn from(value: &UiAncMode) -> Self {
+        match value {
+            UiAncMode::High => AncMode::High,
+            UiAncMode::Mid => AncMode::Mid,
+            UiAncMode::Low => AncMode::Low,
+            UiAncMode::Adaptive => AncMode::Adaptive,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum UiLowLatency {
+    On,
+    Off,
+    Unknown,
+}
+
+#[derive(PartialEq, Eq)]
+enum UiInEarDetection {
+    On,
+    Off,
+    Unknown,
+}
+
+struct MyApp {
+    tx: UnboundedSender<EarCmd>,
+    rx: UnboundedReceiver<EarResponse>,
+    device_info: Option<DeviceInfo>,
+    error: Option<String>,
+    anc: UiAnc,
+    anc_mode: UiAncMode,
+    low_latency_mode: UiLowLatency,
+    in_ear_detection_mode: UiInEarDetection,
+}
+
+impl MyApp {
+    fn new(tx: UnboundedSender<EarCmd>, rx: UnboundedReceiver<EarResponse>) -> Self {
+        Self {
+            tx,
+            rx,
+            device_info: None,
+            error: None,
+            anc: UiAnc::Unknown,
+            anc_mode: UiAncMode::Adaptive,
+            low_latency_mode: UiLowLatency::Unknown,
+            in_ear_detection_mode: UiInEarDetection::Unknown,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        while let Ok(response) = self.rx.try_recv() {
+            match response {
+                EarResponse::DeviceInfo(device_info) => {
+                    self.device_info = Some(device_info);
+                }
+                EarResponse::Error(err) => {
+                    self.error = Some(err);
+                }
+            }
+        }
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Nothing Ear Manager");
+            if let Some(err) = &self.error {
+                ui.colored_label(ctx.style().visuals.error_fg_color, err);
+            }
+            ui.separator();
+            if let Some(device_info) = &self.device_info {
+                egui::Grid::new("DeviceInfo").num_columns(2).show(ui, |ui| {
+                    ui.label("Address:");
+                    ui.label(&device_info.address);
+                    ui.end_row();
+
+                    ui.label("Firmware:");
+                    ui.label(&device_info.firmware_version);
+                    ui.end_row();
+
+                    ui.label("Serial:");
+                    ui.label(&device_info.serial_number);
+                    ui.end_row();
+                });
+            } else {
+                ui.label("Waiting for device...");
+                return;
+            }
+            ui.separator();
+            egui::Grid::new("Anc").num_columns(2).show(ui, |ui| {
+                ui.label("ANC:");
+                ui.vertical(|ui| {
+                    if ui.radio_value(&mut self.anc, UiAnc::Off, "Off").clicked() {
+                        self.tx
+                            .send(EarCmd::AncMode(AncMode::Off))
+                            .expect("sending EarCmd");
+                    }
+                    if ui
+                        .radio_value(&mut self.anc, UiAnc::Transparency, "Transparency")
+                        .clicked()
+                    {
+                        self.tx
+                            .send(EarCmd::AncMode(AncMode::Transparency))
+                            .expect("sending EarCmd");
+                    }
+                    if ui.radio_value(&mut self.anc, UiAnc::On, "On").clicked() {
+                        self.tx
+                            .send(EarCmd::AncMode((&self.anc_mode).into()))
+                            .expect("sending EarCmd");
+                    }
+                });
+                ui.end_row();
+            });
+            ui.separator();
+            ui.add_enabled_ui(self.anc == UiAnc::On, |ui| {
+                egui::Grid::new("AncMode").num_columns(2).show(ui, |ui| {
+                    ui.label("ANC Mode:");
+                    ui.vertical(|ui| {
+                        for mode in [
+                            UiAncMode::High,
+                            UiAncMode::Mid,
+                            UiAncMode::Low,
+                            UiAncMode::Adaptive,
+                        ] {
+                            if ui
+                                .radio_value(&mut self.anc_mode, mode, mode.label())
+                                .clicked()
+                            {
+                                self.tx
+                                    .send(EarCmd::AncMode((&mode).into()))
+                                    .expect("sending EarCmd");
+                            }
+                        }
+                    });
+                    ui.end_row();
+                });
+            });
+            ui.separator();
+            egui::Grid::new("LowLatency").num_columns(2).show(ui, |ui| {
+                ui.label("Low Latency:");
+                ui.vertical(|ui| {
+                    if ui
+                        .radio_value(&mut self.low_latency_mode, UiLowLatency::Off, "Off")
+                        .clicked()
+                    {
+                        self.tx
+                            .send(EarCmd::LowLatency(false))
+                            .expect("sending EarCmd");
+                    }
+                    if ui
+                        .radio_value(&mut self.low_latency_mode, UiLowLatency::On, "On")
+                        .clicked()
+                    {
+                        self.tx
+                            .send(EarCmd::LowLatency(true))
+                            .expect("sending EarCmd");
+                    }
+                });
+                ui.end_row();
+            });
+            ui.separator();
+            egui::Grid::new("InEarDetection")
+                .num_columns(2)
+                .show(ui, |ui| {
+                    ui.label("In Ear Detection:");
+                    ui.vertical(|ui| {
+                        if ui
+                            .radio_value(
+                                &mut self.in_ear_detection_mode,
+                                UiInEarDetection::Off,
+                                "Off",
+                            )
+                            .clicked()
+                        {
+                            self.tx
+                                .send(EarCmd::InEarDetection(false))
+                                .expect("sending EarCmd");
+                        }
+                        if ui
+                            .radio_value(
+                                &mut self.in_ear_detection_mode,
+                                UiInEarDetection::On,
+                                "On",
+                            )
+                            .clicked()
+                        {
+                            self.tx
+                                .send(EarCmd::InEarDetection(true))
+                                .expect("sending EarCmd");
+                        }
+                    });
+                    ui.end_row();
+                });
+        });
+    }
+}


### PR DESCRIPTION
So, this is kinda dirty PR, because UI part of it is not very beautiful (regarding both code style and visual style). **But**, it solves few problems:

* It allows to build a egui-based UI which can be more familiar for many Rust devs (for me it was easier to start hacking with it)
* It fixes the timeout which occurs when reading response with serial number for Nothing Ear (2024) model and adjusts byte offset from which the number is parsed to string

Few words about serial number response for Nothing Ear (2024) model. I added stderr output which logs all bytes received when reading serial number response in case timeout occurs (the timeout is 1 second for now). On my environment there are 145 bytes instead of expected 146 and these bytes are:

```rust
[85, 96, 1, 6, 64, 135, 0, 5, 9, 50, 44, 49, 44, 10, 50, 44, 50, 44, 49, 46, 48, 46, 49, 46, 53, 52, 10, 50, 44, 52, 44, 83, 72, 49, 48, 54, 49, 50, 52, 51, 54, 48, 48, 48, 54, 53, 48, 10, 51, 44, 49, 44, 10, 51, 44, 50, 44, 49, 46, 48, 46, 49, 46, 53, 52, 10, 51, 44, 52, 44, 83, 72, 49, 48, 54, 49, 50, 52, 51, 54, 48, 48, 48, 54, 53, 48, 10, 52, 44, 49, 44, 10, 52, 44, 50, 44, 49, 46, 48, 46, 49, 46, 53, 52, 10, 52, 44, 52, 44, 83, 72, 49, 48, 54, 49, 50, 52, 51, 54, 48, 48, 48, 54, 53, 48, 10, 51, 44, 54, 44, 53, 67, 65, 52, 55, 56, 69, 66, 66, 69, 50, 67, 10, 67, 32]
```
If I try to parse them as UTF-8 I can notice multiple version strings and serial number strings. Probably, the protocol used in Nothing Ear (2024) is a bit different from Nothing Ear (2). Also, serial number offset differs and acceptable `EAR_2024_SERIAL_OFFSET` is chosen instead of `EAR_2_SERIAL_OFFSET` if we detect that parsed serial number contains comma character which is indication for wrong offset used.

![image](https://github.com/user-attachments/assets/9577a03e-101b-4b41-b4db-8242a632129f)

Fixes #2 